### PR TITLE
Implement account, user, reset and track functionality for js sdk

### DIFF
--- a/packages/javascript-sdk/README.md
+++ b/packages/javascript-sdk/README.md
@@ -1,15 +1,4 @@
-# Jitsu JavaScript SDK (jitsu.js)
-
-Jitsu.js is a JavaScript SDK for [Jitsu](https://jitsu.com). Please, see
-main [Jitsu JavaScript integration docs](https://jitsu.com/docs/sending-data/js-sdk) on the website.
-
-## Questions?
-
-### [Join Jitsu Slack](https://jitsu.com/slack)
-
-## Links
-
-- [Official SDK Docs](https://jitsu.com/docs/sending-data/js-sdk)
+# Hyperengage JavaScript SDK (hyperengage-js)
 
 ## Maintainers Guide
 
@@ -20,14 +9,14 @@ This section is indented only for package maintainers.
  * _**ATTENTION**_: Use `yarn` for everything except publishing
  * To spin off a local development server run `yarn devserver`, then open [http://localhost:8081](http://localhost:8081)
    * The server listens to all changes to src and rebuilds npm and `lib.js` automatically. Open test cases HTML files to see
-     jitsu in action
-     * http://localhost:8081/test-case/embed.html - embedded Jitsu
-     * http://localhost:8081/test-case/embed-no-init.html - Jitsu without automatic initialization
+     hyperengage in action
+     * http://localhost:8081/test-case/embed.html - embedded Hyperengage
+     * http://localhost:8081/test-case/embed-no-init.html - Hyperengage without automatic initialization
      * http://localhost:8081/test-case/segment-intercept.html - test segment interception
  * `yarn test` runs [Playwright](https://playwright.dev/) test
  * `yarn build` builds both npm package and `lib.js` browser bundle
  * `npm publish --public` to publish the package (change version in `package.json` manually). You need to run `npm login` with your personal
-npmjs account beforehand (make sure you have access to Jitsu team)
+npmjs account beforehand (make sure you have access to Hyperengage team)
 
 ### Publishing new version
 

--- a/packages/javascript-sdk/__tests__/embedded.test.ts
+++ b/packages/javascript-sdk/__tests__/embedded.test.ts
@@ -30,10 +30,9 @@ test("test embedded no init", async () => {
   expect(requestLog[0].api_key).toBe("Test2");
   expect(requestLog[0].src).toBe("eventn");
   expect(requestLog[0].eventn_ctx.click_id.gclid).toBe("1");
-  expect(requestLog[0].eventn_ctx.user.id).toBe("uid");
-  expect(requestLog[0].eventn_ctx.user.email).toBe("a@b.com");
-  expect(requestLog[0].eventn_ctx.user.anonymous_id).toBe(
-    requestLog[1].eventn_ctx.user.anonymous_id
+  expect(requestLog[0].eventn_ctx_id).toBe("uid");
+  expect(requestLog[0].eventn_ctx.anonymous_id).toBe(
+    requestLog[1].eventn_ctx.anonymous_id
   );
   server.clearRequestLog();
 });
@@ -67,9 +66,9 @@ test("test embedded", async () => {
   await waitFor(() => requestLog.length === 2, 1000)
   expect(requestLog[0].api_key).toBe("Test");
   expect(requestLog[0].click_id.gclid).toBe("1");
-  expect(requestLog[0].user.anonymous_id).toBeDefined();
-  expect(requestLog[0].user.anonymous_id).toBe(requestLog[1].user.anonymous_id);
-  expect(requestLog[1].user.anonymous_id).toBeDefined();
+  expect(requestLog[0].anonymous_id).toBeDefined();
+  expect(requestLog[0].anonymous_id).toBe(requestLog[1].anonymous_id);
+  expect(requestLog[1].anonymous_id).toBeDefined();
   expect(requestLog[1].extra).toBe(1);
   expect(requestLog[1].persistent_prop1).toBe(2);
   expect(requestLog[1].persistent_prop2).toBe(3);
@@ -88,9 +87,9 @@ test("test privacy policy", async () => {
   await waitFor(() => requestLog.length === 2, 1000)
   expect(requestLog[0].api_key).toBe("Test");
   expect(requestLog[0].click_id.gclid).toBe("1");
-  expect(requestLog[0].user.anonymous_id).toBe("");
-  expect(requestLog[0].user.anonymous_id).toBe(requestLog[1].user.anonymous_id);
-  expect(requestLog[1].user.anonymous_id).toBe("");
+  expect(requestLog[0].anonymous_id).toBe("");
+  expect(requestLog[0].anonymous_id).toBe(requestLog[1].anonymous_id);
+  expect(requestLog[1].anonymous_id).toBe("");
   expect(requestLog[1].extra).toBe(1);
   expect(requestLog[1].persistent_prop1).toBe(2);
   expect(requestLog[1].persistent_prop2).toBe(3);
@@ -113,7 +112,7 @@ test("test tag destination", async () => {
   await waitFor(() => requestLog.length === 1, 1000)
   expect(requestLog[0].api_key).toBe("Test");
   expect(requestLog[0].click_id.gclid).toBe("1");
-  expect(requestLog[0].user.anonymous_id).toBeDefined();
+  expect(requestLog[0].anonymous_id).toBeDefined();
   expect(requestLog[0].extra).toBe(1);
   expect(requestLog[0].persistent_prop1).toBe(2);
   expect(requestLog[0].persistent_prop2).toBe(3);

--- a/packages/javascript-sdk/__tests__/npm-browser.test.ts
+++ b/packages/javascript-sdk/__tests__/npm-browser.test.ts
@@ -3,12 +3,12 @@
  *
  * DO NOT DELETE LINE ABOVE, THIS IS AN INSTRUCTION FOR JEST
  *
- * This test suite verifies that Jitsu works as a npm package with DOM
+ * This test suite verifies that Hyperengage works as a npm package with DOM
  * env
  */
 
-import { envs, jitsuClient } from "../src/jitsu";
-import { JitsuClient } from "../src/interface";
+import { envs, hyperengageClient } from "../src/hyperengage";
+import { HyperengageClient } from "../src/interface";
 import { sleep, waitFor } from "./common/common";
 
 type RequestCache = {
@@ -76,8 +76,9 @@ beforeAll(() => {
 
 test("test browser with retries", async () => {
   mockDisabled = true
-  let jitsu: JitsuClient = jitsuClient({
+  let hyperengage: HyperengageClient = hyperengageClient({
     key: "Test",
+    workspace_key: "123",
     tracking_host: "https://test-host.com",
     custom_headers: () => ({
       "test1": "val1",
@@ -88,8 +89,8 @@ test("test browser with retries", async () => {
     max_send_timeout: 10,
   });
 
-  await jitsu.id({ email: "john.doe@gmail.com", id: "1212" });
-  await jitsu.track("page_view", { test: 1 });
+  await hyperengage.user({ traits: {email: "john.doe@gmail.com", name: 'Zeeshan'}, user_id: "1212" });
+  await hyperengage.track("page_view", { properties: {test: 1} });
 
   await sleep(500)
   mockDisabled = false
@@ -103,19 +104,20 @@ test("test browser with retries", async () => {
   expect(requestLog[0].headers?.test1).toBe("val1")
   expect(requestLog[0].headers?.test2).toBe("val2")
 
-  expect(event1?.user?.anonymous_id).toBe(event2?.user?.anonymous_id)
-  expect(event1?.user?.email).toBe('john.doe@gmail.com')
-  expect(event2?.user?.email).toBe('john.doe@gmail.com')
-  expect(event1?.user?.id).toBe('1212')
-  expect(event2?.user?.id).toBe('1212')
+  expect(event1?.anonymous_id).toBe(event2?.anonymous_id)
+  expect(event1?.traits.email).toBe('john.doe@gmail.com')
+  expect(event2?.properties.test).toBe(1)
+  expect(event1?.user_id).toBe('1212')
+  expect(event2?.user_id).toBe('1212')
   expect(event1.event_type).toBe('user_identify')
   expect(event2.event_type).toBe('page_view')
 });
 
 test("test browser sync", async () => {
   let counter = 0
-  let jitsu: JitsuClient = jitsuClient({
+  let hyperengage: HyperengageClient = hyperengageClient({
     key: "Test",
+    workspace_key: "1234",
     tracking_host: "https://test-host.com",
     custom_headers: () => ({
       "test1": "val1",
@@ -123,8 +125,8 @@ test("test browser sync", async () => {
     }),
     max_send_attempts: 1
   });
-  await jitsu.id({ email: "john.doe@gmail.com", id: "1212" });
-  await jitsu.track("page_view", { test: 1 });
+  await hyperengage.user({ traits: {name:'zizou', email: "john.doe@gmail.com"}, user_id: "1212" });
+  await hyperengage.track("page_view", {properties: { test: 1 }});
   expect(requestLog.length).toBe(2)
   console.log("Requests", requestLog)
   const event1 = JSON.parse(requestLog[0].payload)
@@ -136,19 +138,20 @@ test("test browser sync", async () => {
   expect(requestLog[0].headers?.test1).toBe("val1")
   expect(requestLog[1].headers?.test1).toBe("val1")
 
-  expect(event1?.user?.anonymous_id).toBe(event2?.user?.anonymous_id)
-  expect(event1?.user?.email).toBe('john.doe@gmail.com')
-  expect(event2?.user?.email).toBe('john.doe@gmail.com')
-  expect(event1?.user?.id).toBe('1212')
-  expect(event2?.user?.id).toBe('1212')
+  expect(event1?.anonymous_id).toBe(event2?.anonymous_id)
+  expect(event1?.traits.email).toBe('john.doe@gmail.com')
+  expect(event2?.properties.test).toBe(1)
+  expect(event1?.user_id).toBe('1212')
+  expect(event2?.user_id).toBe('1212')
   expect(event1.event_type).toBe('user_identify')
   expect(event2.event_type).toBe('page_view')
 });
 
 test("test browser max attempts exceeded", async () => {
   mockDisabled = true
-  let jitsu: JitsuClient = jitsuClient({
+  let hyperengage: HyperengageClient = hyperengageClient({
     key: "Test",
+    workspace_key: "zeeshhi",
     tracking_host: "https://test-host.com",
     custom_headers: () => ({
       "test1": "val1",
@@ -159,14 +162,14 @@ test("test browser max attempts exceeded", async () => {
     max_send_timeout: 10,
   });
 
-  await jitsu.id({ email: "john.doe@gmail.com", id: "1212" });
-
+  await hyperengage.user({ traits: {email: "john.doe@gmail.com", name: "zeeshi"}, user_id: "1212" });
   await sleep(500)
   mockDisabled = false
 
-  await jitsu.track("page_view", { test: 1 });
+  await hyperengage.track("page_view", { properties: {test: 1} });
 
   await waitFor(() => requestLog.length === 1, 1000)
+
 
   console.log("Requests", requestLog)
   const event2 = JSON.parse(requestLog[0].payload)
@@ -174,7 +177,6 @@ test("test browser max attempts exceeded", async () => {
   expect(requestLog[0].headers?.test1).toBe("val1")
   expect(requestLog[0].headers?.test2).toBe("val2")
 
-  expect(event2?.user?.email).toBe('john.doe@gmail.com')
-  expect(event2?.user?.id).toBe('1212')
+  expect(event2?.user_id).toBe('1212')
   expect(event2.event_type).toBe('page_view')
 });

--- a/packages/javascript-sdk/package.json
+++ b/packages/javascript-sdk/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "@jitsu/sdk-js",
-  "version": "3.1.3",
-  "description": "Jitsu JavaScript SDK (more at http://jitsu.com/docs/js-sdk)",
-  "main": "dist/npm/jitsu.cjs.js",
-  "module": "dist/npm/jitsu.es.js",
-  "types": "dist/npm/jitsu.d.ts",
+  "name": "@hyperengage/sdk-js",
+  "version": "1.0.0",
+  "description": "Hyperengage JavaScript SDK",
+  "main": "dist/npm/hyperengage.cjs.js",
+  "module": "dist/npm/hyperengage.es.js",
+  "types": "dist/npm/hyperengage.d.ts",
   "files": [
     "dist/npm/*",
     "dist/web/*"
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/jitsucom/jitsu-js",
+    "url": "https://github.com/hyperengage/hyperengage-js",
     "directory": "packages/javascript-sdk"
   },
   "publishConfig": {
     "access": "public"
   },
   "private": false,
-  "author": "Jitsu Dev <dev@jitsu.com>",
+  "author": "Hyperengage Dev <dev@hyperengage.com>",
   "scripts": {
     "clean": "rm -rf ./dist",
     "devserver": "PORT=8081 nodemon --watch '__tests__/common/*.ts' --exec 'ts-node' __tests__/common/devserver.ts",

--- a/packages/javascript-sdk/rollup.config.js
+++ b/packages/javascript-sdk/rollup.config.js
@@ -26,7 +26,7 @@ export default [
     },
   },
   {
-    input: `src/jitsu.ts`,
+    input: `src/hyperengage.ts`,
     plugins: [
       typescriptPlugin,
       replace({
@@ -36,13 +36,13 @@ export default [
       }),
       copy({
         targets: [
-          {src: 'src/interface.d.ts', dest: 'dist/npm', rename: 'jitsu.d.ts'}
+          {src: 'src/interface.d.ts', dest: 'dist/npm', rename: 'hyperengage.d.ts'}
         ]
       })
     ],
     output: [
-      {file: 'dist/npm/jitsu.es.js', format: 'es'},
-      {file: 'dist/npm/jitsu.cjs.js', format: 'cjs'},
+      {file: 'dist/npm/hyperengage.es.js', format: 'es'},
+      {file: 'dist/npm/hyperengage.cjs.js', format: 'cjs'},
     ]
   }
 ];

--- a/packages/javascript-sdk/src/browser.ts
+++ b/packages/javascript-sdk/src/browser.ts
@@ -1,12 +1,12 @@
 import { getLogger } from './log';
-import { JitsuClient, JitsuFunction, JitsuOptions } from './interface';
-import { jitsuClient } from './jitsu';
+import { HyperengageClient, HyperengageFunction, HyperengageOptions } from './interface';
+import { hyperengageClient } from './hyperengage';
 
 const jsFileName = "lib.js"
-//Make sure that all properties form JitsuOptions are listed here
-const jitsuProps = [
+//Make sure that all properties form HyperengageOptions are listed here
+const hyperengageProps = [
   'use_beacon_api', 'cookie_domain', 'tracking_host', 'cookie_name',
-  'key', 'ga_hook', 'segment_hook', 'randomize_url', 'capture_3rd_party_cookies',
+  'key', 'workspace_key', 'ga_hook', 'segment_hook', 'randomize_url', 'capture_3rd_party_cookies',
   'id_method', 'log_level', 'compat_mode','privacy_policy', 'cookie_policy', 'ip_policy', 'custom_headers',
   'force_use_fetch', 'min_send_timeout', 'max_send_timeout', 'max_send_attempts', 'disable_event_persistence',
 ];
@@ -20,29 +20,30 @@ const supressInterceptionWarnings = "data-suppress-interception-warning";
 
 function hookWarnMsg(hookType: string) {
   return `
-      ATTENTION! ${hookType}-hook set to true along with defer/async attribute! If ${hookType} code is inserted right after Jitsu tag,
+      ATTENTION! ${hookType}-hook set to true along with defer/async attribute! If ${hookType} code is inserted right after Hyperengage tag,
       first tracking call might not be intercepted! Consider one of the following:
-       - Inject jitsu tracking code without defer/async attribute
-       - If you're sure that events won't be sent to ${hookType} before Jitsu is fully initialized, set ${supressInterceptionWarnings}="true"
+       - Inject hyperengage tracking code without defer/async attribute
+       - If you're sure that events won't be sent to ${hookType} before Hyperengage is fully initialized, set ${supressInterceptionWarnings}="true"
        script attribute
     `;
 }
 
-function getTracker(window): JitsuClient {
+function getTracker(window): HyperengageClient {
 
   let script = document.currentScript
-    || document.querySelector('script[src*=jsFileName][data-jitsu-api-key]');
+    || document.querySelector('script[src*=jsFileName][data-key][data-workspace-key]');
 
   if (!script) {
-    getLogger().warn("Jitsu script is not properly initialized. The definition must contain data-jitsu-api-key as a parameter")
+    getLogger().warn("Hyperengage script is not properly initialized. The definition must contain data-hyperengage-api-key and data-hyperengage-workspace-key as a parameter")
     return undefined;
   }
-  let opts: JitsuOptions = {
+  let opts: HyperengageOptions = {
     tracking_host: getTrackingHost(script.getAttribute('src')),
+    workspace_key: null,
     key: null
   };
 
-  jitsuProps.forEach(prop => {
+  hyperengageProps.forEach(prop => {
     let attr = "data-" + prop.replace(new RegExp("_", "g"), "-");
     if (script.getAttribute(attr) !== undefined && script.getAttribute(attr) !== null) {
       let val: any = script.getAttribute(attr);
@@ -54,7 +55,7 @@ function getTracker(window): JitsuClient {
       opts[prop] = val;
     }
   })
-  window.jitsuClient = jitsuClient(opts)
+  window.hyperengageClient = hyperengageClient(opts)
   if (opts.segment_hook && (script.getAttribute('defer') !== null || script.getAttribute('async') !== null) && script.getAttribute(supressInterceptionWarnings) === null) {
     getLogger().warn(hookWarnMsg("segment"))
   }
@@ -62,26 +63,26 @@ function getTracker(window): JitsuClient {
     getLogger().warn(hookWarnMsg("ga"))
   }
 
-  const jitsu: JitsuFunction = function() {
-    let queue = window.jitsuQ = window.jitsuQ || [];
+  const hyperengage: HyperengageFunction = function() {
+    let queue = window.hyperengageQ = window.hyperengageQ || [];
     queue.push(arguments)
-    processQueue(queue, window.jitsuClient);
+    processQueue(queue, window.hyperengageClient);
   }
-  window.jitsu = jitsu;
+  window.hyperengage = hyperengage;
 
   if ("true" !== script.getAttribute("data-init-only") && "yes" !== script.getAttribute("data-init-only")) {
-    jitsu('track', 'pageview');
+    hyperengage('track', 'pageview');
   }
-  return window.jitsuClient;
+  return window.hyperengageClient;
 }
 
-function processQueue(queue: any[], jitsuInstance: JitsuClient) {
+function processQueue(queue: any[], hyperengageInstance: HyperengageClient) {
   getLogger().debug("Processing queue", queue);
   for (let i = 0; i < queue.length; i += 1) {
     const [methodName, ...args] = ([...queue[i]] || []);
-    const method = (jitsuInstance as any)[methodName];
+    const method = (hyperengageInstance as any)[methodName];
     if (typeof method === 'function') {
-      method.apply(jitsuInstance, args);
+      method.apply(hyperengageInstance, args);
     }
   }
   queue.length = 0;
@@ -91,21 +92,21 @@ if (window) {
   let win = window as any;
   let tracker = getTracker(win);
   if (tracker) {
-    getLogger().debug("Jitsu in-browser tracker has been initialized")
-    win.jitsu = function() {
-      let queue = win.jitsuQ = win.jitsuQ || [];
+    getLogger().debug("Hyperengage in-browser tracker has been initialized")
+    win.hyperengage = function() {
+      let queue = win.hyperengageQ = win.hyperengageQ || [];
       queue.push(arguments)
       processQueue(queue, tracker);
     }
-    if (win.jitsuQ) {
-      getLogger().debug(`Initial queue size of ${win.jitsuQ.length} will be processed`);
-      processQueue(win.jitsuQ, tracker);
+    if (win.hyperengageQ) {
+      getLogger().debug(`Initial queue size of ${win.hyperengageQ.length} will be processed`);
+      processQueue(win.hyperengageQ, tracker);
     }
   } else {
-    getLogger().error("Jitsu tracker has not been initialized (reason unknown)")
+    getLogger().error("Hyperengage tracker has not been initialized (reason unknown)")
   }
 } else {
-  getLogger().warn("Jitsu tracker called outside browser context. It will be ignored")
+  getLogger().warn("Hyperengage tracker called outside browser context. It will be ignored")
 }
 
 

--- a/packages/javascript-sdk/src/helpers.ts
+++ b/packages/javascript-sdk/src/helpers.ts
@@ -8,6 +8,30 @@ export const getCookieDomain = () => {
   return undefined;
 };
 
+export const verifyTraits = (props: any, type: 'account' | 'user') => {
+  if (type === 'account') {
+    if(!props?.account_id) {
+      return false
+    }
+    if(!props?.traits?.name) {
+      return false
+    }
+    return true;
+  }
+  else if(type === 'user') {
+    if(!props?.user_id) {
+      return false
+    }
+    if(!props?.traits?.name) {
+      return false
+    }
+    if(!props?.traits?.email) {
+      return false
+    }
+    return true;
+  }
+}
+
 let cookieParsingCache: Record<string, string>;
 
 export function parseCookieString(cookieStr?: string) {
@@ -45,7 +69,7 @@ export function insertAndExecute(element: HTMLElement, html: string) {
     if (script.innerHTML) {
       tag.innerHTML = script.innerHTML;
     }
-    tag.setAttribute("data-jitsu-tag-id", element.id);
+    tag.setAttribute("data-hyperengage-tag-id", element.id);
     document.getElementsByTagName("head")[0].appendChild(tag);
     scripts[index].parentNode.removeChild(scripts[index]);
   }

--- a/packages/javascript-sdk/src/interface.d.ts
+++ b/packages/javascript-sdk/src/interface.d.ts
@@ -1,6 +1,6 @@
-export declare function jitsuClient(opts: JitsuOptions): JitsuClient
+export declare function hyperengageClient(opts: HyperengageOptions): HyperengageClient
 
-export type JitsuClient = {
+export type HyperengageClient = {
   /**
    * Sends a third-party event (event intercepted from third-party system, such as analytics.js or GA). Should
    * not be called directly
@@ -17,7 +17,8 @@ export type JitsuClient = {
    * @param payload event payload
    * @return Promise, see _send3p documentation
    */
-  track: (typeName: string, payload?: EventPayload) => Promise<void>
+
+  track: (type: string, payload?: EventPayload) => Promise<void>
 
   // /**
   //  * Similar to track(), but send unstructured payload to EventNative processing pipeline. No
@@ -32,12 +33,23 @@ export type JitsuClient = {
    * @param doNotSendEvent if true (false by default), separate "id" event won't be sent to server
    * @return Promise, see _send3p documentation
    */
-  id: (userData: UserProps, doNotSendEvent?: boolean) => Promise<void>
+  user: (userData: UserProps, doNotSendEvent?: boolean) => Promise<void>
+
+    /**
+   * Sets a user data
+   * @param accountData user data (as map id_type --> value, such as "email": "a@bcd.com"
+   * @param doNotSendEvent if true (false by default), separate "id" event won't be sent to server
+   * @return Promise, see _send3p documentation
+   */
+  account: (accountData: AccountProps, doNotSendEvent?: boolean) => Promise<void>
+
+  reset: () => Promise<void>
+  
   /**
    * Initializes tracker. Must be called
    * @param initialization options
    */
-  init: (opts: JitsuOptions) => void
+  init: (opts: HyperengageOptions) => void
 
   /**
    * Explicit call for intercepting Segment's analytics.
@@ -59,13 +71,11 @@ export type JitsuClient = {
    * User
    */
   unset(propertyName: string, opts: { eventType?: string, persist?: boolean });
-
 }
-
 /**
- * Type of jitsu function which is exported to window.jitsu when tracker is embedded from server
+ * Type of hyperengage function which is exported to window.hyperengage when tracker is embedded from server
  */
-export type JitsuFunction = (action: 'track' | 'id' | 'set', eventType: string, payload?: EventPayload) => void;
+export type HyperengageFunction = (action: 'track' | 'id' | 'set', eventType: string, payload?: EventPayload) => void;
 
 /**
  * User identification method:
@@ -77,23 +87,23 @@ export type IdMethod = 'cookie' | 'ls'
 
 /**
  * Policy configuration affects cookies storage and IP handling.
- *  - strict: Jitsu doesn't store cookies and replaces last octet in IP address (10.10.10.10 -> 10.10.10.1)
- *  - keep: Jitsu uses cookies for user identification and saves full IP
- *  - comply: Jitsu checks customer country and tries to comply with Regulation laws (such as GDPR, UK's GDPR (PECR) and California's GDPR (CCPA)
+ *  - strict: Hyperengage doesn't store cookies and replaces last octet in IP address (10.10.10.10 -> 10.10.10.1)
+ *  - keep: Hyperengage uses cookies for user identification and saves full IP
+ *  - comply: Hyperengage checks customer country and tries to comply with Regulation laws (such as GDPR, UK's GDPR (PECR) and California's GDPR (CCPA)
  */
 export type Policy = 'strict' | 'keep' | 'comply'
 
 /**
- * Configuration options of Jitsu
+ * Configuration options of Hyperengage
  */
-export type JitsuOptions = {
+export type HyperengageOptions = {
 
   /**
-   * A custom fetch implementation. Here's how Jitsu decides what functions to use to execute HTTP requests
+   * A custom fetch implementation. Here's how Hyperengage decides what functions to use to execute HTTP requests
    *
-   * - If Jitsu runs in browser, this parameter will be ignored. The best available API (most likely, XMLHttpRequest)
+   * - If Hyperengage runs in browser, this parameter will be ignored. The best available API (most likely, XMLHttpRequest)
    *   will be used for sending reqs
-   * - For node Jitsu will use this param. If it's not set, Jitsu will try to search for fetch in global environment
+   * - For node Hyperengage will use this param. If it's not set, Hyperengage will try to search for fetch in global environment
    *   and will fail if it's absent
    *
    *
@@ -102,13 +112,13 @@ export type JitsuOptions = {
   fetch?: any,
 
   /**
-   * Forces Jitsu SDK to use the fetch implementation (custom or default) even in browser
+   * Forces Hyperengage SDK to use the fetch implementation (custom or default) even in browser
    */
   force_use_fetch?: any,
 
   /**
-   * If Jitsu should work in compatibility mode. If set to true:
-   *  - event_type will be set to 'eventn' instead of 'jitsu'
+   * If Hyperengage should work in compatibility mode. If set to true:
+   *  - event_type will be set to 'eventn' instead of 'hyperengage'
    *  - EventCtx should be written in eventn_ctx node as opposed to to event root
    */
   compat_mode?: boolean
@@ -129,7 +139,7 @@ export type JitsuOptions = {
   cookie_domain?: string
   /**
    * Tracking host (where API calls will be sent). If not set,
-   * we'd try to do the best to "guess" it. Last resort is t.jitsu.com.
+   * we'd try to do the best to "guess" it. Last resort is t.hyperengage.com.
    *
    * Though this parameter is not required, it's highly recommended to set is explicitly
    */
@@ -144,6 +154,7 @@ export type JitsuOptions = {
    * in some cases (where server is configured with exactly one client key)
    */
   key: string
+  workspace_key: string
   /**
    * If google analytics events should be intercepted. Read more about event interception
    * at https://docs.eventnative.org/sending-data/javascript-reference/events-interception
@@ -166,7 +177,7 @@ export type JitsuOptions = {
   randomize_url?: boolean
 
   /**
-   * If Jitsu should capture third-party cookies: either array
+   * If Hyperengage should capture third-party cookies: either array
    * of cookies name or false if the features should be disabled
    *
    * @default GA/Segment/Fb cookies: ['_ga': '_fbp', '_ym_uid', 'ajs_user_id', 'ajs_anonymous_id']
@@ -228,18 +239,35 @@ export type JitsuOptions = {
    */
   disable_event_persistence?: boolean
 
-  //NOTE: If any property is added here, please make sure it's added to browser.ts jitsuProps as well
+  //NOTE: If any property is added here, please make sure it's added to browser.ts hyperengageProps as well
 };
 
 /**
  * User properties (ids).
  */
-export interface UserProps {
+export type UserProps = {
   anonymous_id?: string             //anonymous is (cookie or ls based),
-  id?: string                       //user id (non anonymous). If not set, first known id (from propName below) will be used
-  email?: string                    //user id (non anonymous). If not set, first known id (from propName below) will be used
-  [propName: string]: any           //any other forms of ids
+  user_id: string                       //user id (non anonymous). If not set, first known id (from propName below) will be used
+  account_id?: string
+  traits : {
+    email: string,         
+    name: string,           
+    [traitName: string]: any,           //any other forms of ids
+  }
+} | {
+  anonymous_id?: string        
+  user_id?: undefined  
+  traits?: never
 }
+
+export type AccountProps = {
+  account_id: string                       //Account id (non anonymous). If not set, first known id (from propName below) will be used
+  traits: {
+    name: string                    //Required name of the account
+    [traitName: string]: any         //any other forms of ids
+  }
+} | {
+};
 
 /**
  * Ids for third-party tracking systems
@@ -267,11 +295,12 @@ export type Conversion = {
  */
 export type EventCtx = {
   event_id: string                 //unique event id or empty string for generating id on the backend side
-  user: UserProps                  //user properties
+  anonymous_id?: string
+  user_id: UserProps | string
+  account_id: AccountProps | string            //account properties
   ids?: ThirdpartyIds              //user ids from external systems
   utc_time: string                 //current UTC time in ISO 8601
   local_tz_offset: number          //local timezone offset (in minutes)
-
   utm: Record<string, string>      //utm tags (without utm prefix, e.g key will be "source", not utm_source. See
   click_id: Record<string, string> //all external click ids (passed through URL). See CLICK_IDS for supported all supported click ids
   [propName: string]: any          //context is extendable, any extra properties can be added here
@@ -287,7 +316,7 @@ export type TrackingEnvironment = {
    */
   describeClient(): Partial<ClientProperties>;
   /**
-   * Returns source ip. If IP should be resolved by Jitsu server, this method should return undefined
+   * Returns source ip. If IP should be resolved by Hyperengage server, this method should return undefined
    */
   getSourceIp(): string | undefined;
 
@@ -298,7 +327,7 @@ export type TrackingEnvironment = {
   getAnonymousId(cookieOpts: { name: string, domain?: string }): string;
 };
 /**
- * List of environments where Jitsu tracker can work. See TrackingEnvironment above
+ * List of environments where Hyperengage tracker can work. See TrackingEnvironment above
  * to learn what is the environment
  */
 export type Envs = {
@@ -363,7 +392,7 @@ export type ClientProperties = {
 export type EventPayload = Partial<ClientProperties> & {
   /**
    * If track() is called in node env, it's possible to provide
-   * request/response. In this case Jitsu will try to use it for
+   * request/response. In this case Hyperengage will try to use it for
    * getting request data (url, referer and etc). Also, it will be used for
    * setting and getting cookies
    */
@@ -373,15 +402,20 @@ export type EventPayload = Partial<ClientProperties> & {
 
   conversion?: Conversion          //Conversion data if events indicates a conversion
   src_payload?: any,               //Third-party payload if event is intercepted from third-party source
-  [propName: string]: any          //payload is extendable, any extra properties can be added here
+  properties?: {
+    [propName: string]: any          //payload is extendable, any extra properties can be added here
+  }
+  traits?: {
+    [traitName: string]: any          //payload is extendable, any extra properties can be added here
+  }
 }
 
 /**
  * Type of event source
  */
 export type EventSrc =
-  'jitsu'    |                     //event came directly from Jitsu
-  'eventn'   |                     //same as jitsu but for 'compat' mode, see
+  'hyperengage'    |                     //event came directly from Hyperengage
+  'eventn'   |                     //same as hyperengage but for 'compat' mode, see
   'ga'       |                     //event is intercepted from GA
   '3rdparty' |                     //event is intercepted from 3rdparty source
   'ajs';                           //event is intercepted from analytics.js
@@ -393,6 +427,7 @@ export type EventBasics = {
   source_ip?: string               //IP address. Do not set this field on a client side, it will be rewritten on the server
   anon_ip?: string                 //First 3 octets of an IP address. Same as IP - will be set on a server
   api_key: string                  //JS api key
+  workspace_key: string            //Hyperengage workspace key
   src: EventSrc                    //Event source
   event_type: string               //event type
 }

--- a/packages/javascript-sdk/src/log.ts
+++ b/packages/javascript-sdk/src/log.ts
@@ -55,10 +55,10 @@ export function setDebugVar(name: string, val: any) {
     return;
   }
   let win = window as any;
-  if (!win.__jitsuDebug) {
-    win.__jitsuDebug = { };
+  if (!win.__hyperengageDebug) {
+    win.__hyperengageDebug = { };
   }
-  win.__jitsuDebug[name] = val;
+  win.__hyperengageDebug[name] = val;
 }
 
 


### PR DESCRIPTION
## Proposed changes

Added functionality for
- Account calls to setup and store accounts in cookies.
- Sending account and user id on each track call
- Reset functionality to flush queue, reset cookies and clear user and account props on logout.
- Restructured javascript sdk to accomodate new functionality.

## Types of changes

What types of changes does your code introduce to Hyperengage?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...